### PR TITLE
Add support for nix environment variables

### DIFF
--- a/lib/scopes/core.sc
+++ b/lib/scopes/core.sc
@@ -3424,6 +3424,22 @@ let modules = (sc_global_new 'modules Scope 0:u32 'Private)
 sc_global_set_initializer modules `[(Scope)]
 let modules = `(ptrtoref modules)
 
+# fn split-flags (flags)
+#     """"Splits a string at each space, returning the two pieces.
+#         Used later to split a string into an array.
+#     local res : (Array string)
+#     local j = 0
+#     for i c in (enumerate flags)
+#         if (c == " ")
+#             let it = (slice flags j i)
+#             'append res it
+#             j = i
+
+#     return res
+
+# (dump (split-flags "foo bar"))
+
+
 """"`__env` is a special symbol table of type `Scope` describing the module
     environment. `import`, `include` and `shared-library` depend on its
     contents. Modules imported with `import` inherit the environment presently

--- a/lib/scopes/core.sc
+++ b/lib/scopes/core.sc
@@ -8885,15 +8885,10 @@ fn set-project-dir (env path set-paths?)
             project-dir = path
     if set-paths?
         let nix-env-modules = (sc_getenv "BuildInputs")
-        print nix-env-modules
         let p1 = (.. path str"/lib/scopes/packages/?.sc")
-        print p1
         let p2 = (.. path str"/lib/scopes/packages/?/init.sc")
-        print p2
         local path-list = (cons p1 (cons p2 (list)))
-        print path-list
         if (nix-env-modules != "") (path-list = (cons nix-env-modules path-list)) # If nix-env-modules isn't empty, this sticks it in the front
-        print path-list
         # add default paths to package
         'bind-symbols env
             module-search-path =

--- a/lib/scopes/core.sc
+++ b/lib/scopes/core.sc
@@ -8888,7 +8888,7 @@ fn set-project-dir (env path set-paths?)
         let p1 = (.. path str"/lib/scopes/packages/?.sc")
         let p2 = (.. path str"/lib/scopes/packages/?/init.sc")
         local path-list = (cons p1 (cons p2 (list)))
-        if (nix-env-modules != "") (path-list = (cons nix-env-modules path-list)) # If nix-env-modules isn't empty, this sticks it in the front
+        if (nix-env-modules != "") (path-list = (.. (split-flags nix-env-modules) path-list)) # If nix-env-modules isn't empty, this sticks it in the front
         # add default paths to package
         'bind-symbols env
             module-search-path =

--- a/lib/scopes/core.sc
+++ b/lib/scopes/core.sc
@@ -8884,16 +8884,21 @@ fn set-project-dir (env path set-paths?)
         'bind-symbols (global-scope)
             project-dir = path
     if set-paths?
-        #let nix-env-modules = (sc_getenv "buildInputs")
-        # let p1 = (.. path str"/lib/scopes/packages/?.sc")
-        # let p2 = (.. path str"/lib/scopes/packages/?/init.sc")
-        # let path-list = (cons p1 (cons p2 (list)))
+        let nix-env-modules = (sc_getenv "BuildInputs")
+        print nix-env-modules
+        let p1 = (.. path str"/lib/scopes/packages/?.sc")
+        print p1
+        let p2 = (.. path str"/lib/scopes/packages/?/init.sc")
+        print p2
+        local path-list = (cons p1 (cons p2 (list)))
+        print path-list
+        if (nix-env-modules != "") (path-list = (cons nix-env-modules path-list)) # If nix-env-modules isn't empty, this sticks it in the front
+        print path-list
         # add default paths to package
         'bind-symbols env
             module-search-path =
-                cons
-                    .. path str"/lib/scopes/packages/?.sc"
-                    .. path str"/lib/scopes/packages/?/init.sc"
+                ..
+                    path-list
                     ('@ env 'module-search-path) as list
             include-search-path =
                 cons


### PR DESCRIPTION
Takes the BuildInputs environment variable using sc_getenv, checks if it's empty, then splits it and builds the appropriate paths to include Scopes libraries from, putting them in module-search-path.