### PR TITLE
flake: nixpkgs nixos-21.11 -> nixos-22.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,16 +48,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1650998007,
-        "narHash": "sha256-NcJnbGDBBN023x8s3ll3HZxBcQoPq1ry9E2sjg+4flc=",
+        "lastModified": 1674242456,
+        "narHash": "sha256-yBy7rCH7EiBe9+CHZm9YB5ii5GRa+MOxeW0oDEBO8SE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3917caedfead19f853aa5769de4c3ea4e4db584",
+        "rev": "cdead16a444a3e5de7bc9b0af8e198b11bb01804",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-21.11",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Scopes retargetable programming language & infrastructure";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-21.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.11";
     genie-src.url = "github:bkaradzic/genie";
     genie-src.flake = false;
     spirv-cross-src.url = "github:KhronosGroup/SPIRV-Cross";


### PR DESCRIPTION
```
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a3917caedfead19f853aa5769de4c3ea4e4db584' (2022-04-26)
  → 'github:nixos/nixpkgs/cdead16a444a3e5de7bc9b0af8e198b11bb01804' (2023-01-20)
```

The `nixpkgs` here is pinned to NixOS 21.11, I'm bumping it to 22.11.

The `feathergui` flake is following the scopes `nixpkgs` input and the older `libglvnd` in 21.11 `nixpkgs` is buggy on some systems and will make GL init fail. Since it follows this repo I figured I should bump it here.

See [this support thread](https://discord.com/channels/575089630647681046/1066885623253827694) for more details.

`nix flake check` / unit tests seem happy but I haven't tested further.

This could cause issues with flakes which depend on this and I have not tested them all. As an example, feather's sail dep fails to build after the bump without https://github.com/HappySeaFox/sail/pull/187 as nixpkgs's cmake hooks became more strict about producing valid pkg-config files.